### PR TITLE
Support host:port proxy backend

### DIFF
--- a/backend_pool.go
+++ b/backend_pool.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"regexp"
 	"sync"
 )
 
@@ -69,8 +68,6 @@ func (p *BackendPool) Close() {
 	}
 }
 
-var hostRegex = regexp.MustCompile("([a-z_\\-0-9A-Z]+)")
-
 func appNameFromHost(host string) string {
-	return hostRegex.FindString(host)
+	return host[0:len(host)-4]
 }


### PR DESCRIPTION
_Disclaimer:_ I've never written anything in go before, so I may not have done everything perfectly here.

I added support for [Port Proxying](http://pow.cx/manual.html#section_2.1.4) as supported by [pow](https://github.com/basecamp/pow).  In the process, the following changes were also made:
- Wildcard domain support for `.dev` (so with `~/.pow/myapp` defined, you can go do any subdomain of `http://*.myapp.dev`)
- Read/write IO directly for websocket proxying instead of message-based read/write (implementation mostly from [koding/websocketproxy](https://github.com/koding/websocketproxy)).

As an example of valid port or host:port combinations, all of the following are the same (assuming the local server is bound to IPv4 and IPv6):

``` bash
echo 8080 > ~/.pow/proxiedapp
echo 127.0.0.1:8080 > ~/.pow/proxiedapp
echo [::1]:8080 > ~/.pow/proxiedapp
echo http://127.0.0.1:8080 > ~/.pow/proxiedapp
echo http://[::1]:8080 > ~/.pow/proxiedapp
```

Thank you for sharing this project, pow's lack of websocket support has been a huge annoyance for me.
