### PR TITLE
Non blocking backend spawning and better subdomain support

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -280,7 +280,7 @@ func (b *Backend) SpawnBackendProxy() error {
 		go b.watchForActivity()
 
 		return nil
-	case <-time.After(30 * time.Second):
+	case <-time.After(5 * time.Second):
 		log.Println(b.appPath, "failed to bind")
 		return errors.New("app failed to bind")
 	}

--- a/backend_pool.go
+++ b/backend_pool.go
@@ -76,7 +76,11 @@ func (p *BackendPool) findSpawnableAppName(host string) string {
 	for name != "" && ok == false {
 		ok = IsSpawnableBackend(name)
 		if ok == false {
-			name = hostDropFirst(name)
+			if strings.Contains(name, ".") {
+				name = hostDropFirst(name)
+			} else {
+				name = ""
+			}
 		}
 	}
 	if name == "" {

--- a/backend_pool.go
+++ b/backend_pool.go
@@ -16,27 +16,19 @@ func NewBackendPool() *BackendPool {
 }
 
 func (p *BackendPool) Select(host string) (string, error) {
-	// Yes, we are this crazy. Lock the mutex during the entire lookup time, which could potentially include
-	// (re)spawning an application. Serialize all of this so that we never have to deal with thundering-herd
-	// spawns and such.
-	// TODO: we could at least lock the spawn process by app name
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
+	name := p.findSpawnableAppName(host)
 
-	name := appNameFromHost(host)
 	var err error
-	p.restartIfRequested(name)
+	backend, err := p.maybeInitBackend(name)
 
-	backend := p.backends[name]
+	if err != nil {
+		return "", err
+	}
 
-	if backend == nil {
-		backend, err = SpawnBackend(name)
+	err = backend.MaybeSpawnBackend()
 
-		if err == nil {
-			p.backends[name] = backend
-		} else {
-			return "", err
-		}
+	if err != nil {
+		return "", err
 	}
 
 	backend.Touch()
@@ -44,23 +36,53 @@ func (p *BackendPool) Select(host string) (string, error) {
 	return backend.Address(), nil
 }
 
-func (p *BackendPool) restartIfRequested(name string) error {
-	if p.backends[name] == nil || !p.backends[name].IsRestartRequested() {
-		return nil
+func (p *BackendPool) maybeInitBackend(name string) (*Backend, error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	var err error
+	backend := p.backends[name]
+
+	if backend == nil {
+		backend, err = InitBackend(name)
+
+		if err == nil {
+			p.backends[name] = backend
+		} else {
+			return nil, err
+		}
+	} else if backend.IsRestartRequested() {
+		log.Println("restarting", name)
+
+		p.backends[name] = nil
+		backend.Close()
+
+		refreshed_backend, err := InitBackend(name)
+
+		if err != nil {
+			return nil, err
+		}
+
+		p.backends[name] = refreshed_backend
+		backend = refreshed_backend
 	}
-	log.Println("restarting", name)
 
-	p.backends[name].Close()
+	return backend, nil
+}
 
-	refreshed_backend, err := SpawnBackend(name)
-
-	if err != nil {
-		return err
+func (p *BackendPool) findSpawnableAppName(host string) string {
+	name := hostDropLast(host)
+	ok := false
+	for name != "" && ok == false {
+		ok = IsSpawnableBackend(name)
+		if ok == false {
+			name = hostDropFirst(name)
+		}
 	}
-
-	p.backends[name] = refreshed_backend
-
-	return nil
+	if name == "" {
+		return host
+	}
+	return name
 }
 
 func (p *BackendPool) Close() {
@@ -69,14 +91,19 @@ func (p *BackendPool) Close() {
 	}
 }
 
-func appNameFromHost(host string) string {
-	return appNameWithoutSubdomains(host[0 : len(host)-4])
-}
-
-func appNameWithoutSubdomains(host string) string {
+func hostDropFirst(host string) string {
 	dotIndex := strings.Index(host, ".")
 	if dotIndex != -1 {
-		return appNameWithoutSubdomains(host[dotIndex+1 : len(host)])
+		return host[dotIndex+1 : len(host)]
+	} else {
+		return host
+	}
+}
+
+func hostDropLast(host string) string {
+	dotIndex := strings.LastIndex(host, ".")
+	if dotIndex != -1 {
+		return host[0:dotIndex]
 	} else {
 		return host
 	}

--- a/backend_pool.go
+++ b/backend_pool.go
@@ -28,6 +28,8 @@ func (p *BackendPool) Select(host string) (string, error) {
 	err = backend.MaybeSpawnBackend()
 
 	if err != nil {
+		p.backends[name] = nil
+		backend.Close()
 		return "", err
 	}
 

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -37,7 +37,10 @@ sudo tee /Library/LaunchDaemons/com.jonasschneider.gow.firewall.plist > /dev/nul
   <array>
     <string>/bin/sh</string>
     <string>-c</string>
-    <string>echo "rdr pass inet proto tcp from any to self port {80,20559} -> 127.0.0.1 port 20559" | pfctl -a "com.apple/250.PowFirewall" -f - -E</string>
+    <string>
+      sysctl -w net.inet.ip.forwarding=1;
+      echo "rdr pass inet proto tcp from any to self port {80,20559} -> 127.0.0.1 port 20559" | pfctl -a "com.apple/250.PowFirewall" -Ef -
+    </string>
   </array>
   <key>RunAtLoad</key>
   <true/>


### PR DESCRIPTION
This pull request implements a non-blocking solution while launching backends and (hopefully) better support for subdomains.

The non-blocking logic simply has a `BackendPool` mutex and a `Backend` mutex.  The `BackendPool` mutex only locks long enough to initialize a new `Backend`.  Then, the individual `Backend` mutex locks in order to spawn the backend.

The subdomain behavior is to drop the last name from the host (so `sub.test.dev` becomes `sub.test`) and check whether a file/directory/symlink exists under `~/.pow`.  If not, it drops the first name from the host (so `sub.test` becomes `test`) and runs the check again.  Once a suitable file has been found, it launches a backend using the found name.

For example:

``` bash
echo 3000 > ~/.pow/test
echo 3001 > ~/.pow/a.test
echo 3002 > ~/.pow/a.a.test
echo 3003 > ~/.pow/b.test
```

Would result in:

```
http://test.dev       -> http://127.0.0.1:3000
http://a.test.dev     -> http://127.0.0.1:3001
http://b.test.dev     -> http://127.0.0.1:3003
http://c.test.dev     -> http://127.0.0.1:3000
http://z.a.test.dev   -> http://127.0.0.1:3001
http://a.a.test.dev   -> http://127.0.0.1:3002
http://z.a.a.test.dev -> http://127.0.0.1:3002
```
